### PR TITLE
DiagnosticVehicleFailureSeeder check added

### DIFF
--- a/Seeders/DiagnosticVehicleFailureSeeder.cs
+++ b/Seeders/DiagnosticVehicleFailureSeeder.cs
@@ -6,9 +6,10 @@ namespace WorkshopsGov.Seeders
     {
         public static void Seed(ApplicationDbContext context)
         {
+            if (context.VehicleFailures.Any()) return;
             var diagnostic = context.Diagnostics.FirstOrDefault();
             var vehicleFailure = context.VehicleFailures.FirstOrDefault();
-        
+            
             if (diagnostic != null && vehicleFailure != null)
             {
                 diagnostic.VehicleFailures.Add(vehicleFailure);


### PR DESCRIPTION
DiagnosticVehicleFailureSeeder no comprueba si ya existe un registro haciendo que si ya existia ocurriera un error, se soluciono